### PR TITLE
clean code

### DIFF
--- a/PresenceInsightsSDK/PresenceInsightsSDK/PIBeacon.swift
+++ b/PresenceInsightsSDK/PresenceInsightsSDK/PIBeacon.swift
@@ -21,18 +21,18 @@ import UIKit
 import CoreLocation
 
 // MARK: - PIBeacon object
-public class PIBeacon: NSObject {
+public struct PIBeacon {
     
     // Beacon properties
-    public var name: String!
-    public var beaconDescription: String!
-    public var proximityUUID: NSUUID!
-    public var major: String!
-    public var minor: String!
-    public var x: CGFloat!
-    public var y: CGFloat!
-    public var site: String!
-    public var floor: String!
+    public let name: String?
+    public let beaconDescription: String?
+    public let proximityUUID: NSUUID?
+    public let major: CLBeaconMajorValue?
+    public let minor: CLBeaconMinorValue?
+    public let x: CGFloat?
+    public let y: CGFloat?
+    public let site: String?
+    public let floor: String?
     
     /**
     Default object initializer.
@@ -43,16 +43,16 @@ public class PIBeacon: NSObject {
     - parameter major:           Unique identifier within the proximity UUID space
     - parameter minor:           Unique identifier within the major space
     */
-    public init(name: String, description: String, proximityUUID: NSUUID, major: String, minor: String) {
+    public init(name: String, description: String, proximityUUID: NSUUID, major: CLBeaconMajorValue, minor: CLBeaconMinorValue) {
         self.name = name
         self.beaconDescription = description
         self.proximityUUID = proximityUUID
         self.major = major
         self.minor = minor
-        self.x = 0.0
-        self.y = 0.0
-        self.site = ""
-        self.floor = ""
+        self.x = nil
+        self.y = nil
+        self.site = nil
+        self.floor = nil
     }
     
     /**
@@ -60,8 +60,16 @@ public class PIBeacon: NSObject {
     
     - returns: An initialized PIBeacon.
     */
-    public convenience override init() {
-        self.init(name: "", description: "", proximityUUID: NSUUID(), major: "", minor: "")
+    public init() {
+        self.name = nil
+        self.beaconDescription = nil
+        self.proximityUUID = NSUUID()
+        self.major = nil
+        self.minor = nil
+        self.x = nil
+        self.y = nil
+        self.site = nil
+        self.floor = nil
     }
     
     /**
@@ -73,12 +81,16 @@ public class PIBeacon: NSObject {
 
     - returns: An initialized PIBeacon.
     */
-    public convenience init(name: String, description: String, beacon: CLBeacon) {
-        let proximityUUID = beacon.proximityUUID
-        let major = beacon.major.stringValue
-        let minor = beacon.minor.stringValue
-        
-        self.init(name: name, description: description, proximityUUID: proximityUUID, major: major, minor: minor)
+    public init(name: String, description: String, beacon: CLBeacon) {
+        self.name = name
+        self.beaconDescription = description
+        self.proximityUUID = beacon.proximityUUID
+        self.major = beacon.major.unsignedShortValue
+        self.minor = beacon.minor.unsignedShortValue
+        self.x = nil
+        self.y = nil
+        self.site = nil
+        self.floor = nil
     }
     
     /**
@@ -88,31 +100,51 @@ public class PIBeacon: NSObject {
 
     - returns: An initialized PIBeacon.
     */
-    public convenience init(dictionary: [String: AnyObject]) {
+    public init?(dictionary: [String: AnyObject]) {
         
         // I prefer this method because if the dictionary isn't built correctly it will at least throw a nil error at runtime.
-        self.init(name: "", description: "", proximityUUID: NSUUID(), major: "", minor: "")
         
         // retrieve dictionaries from feature object
         let geometry = dictionary[GeoJSON.GEOMETRY_KEY] as! [String: AnyObject]
         let properties = dictionary[GeoJSON.PROPERTIES_KEY] as! [String: AnyObject]
         
-        self.name = properties[Beacon.JSON_NAME_KEY] as! String
-        if let beaconDescription = properties[Beacon.JSON_DESCRIPTION_KEY] as? String {
-            self.beaconDescription = beaconDescription;
-        }
-        if let uuid = NSUUID(UUIDString: properties[Beacon.JSON_UUID_KEY] as! String) {
-            self.proximityUUID = uuid
-        }
-        self.major = properties[Beacon.JSON_MAJOR_KEY] as! String
-        self.minor = properties[Beacon.JSON_MINOR_KEY] as! String
-        self.site = properties[Beacon.JSON_SITE_KEY] as! String
-        self.floor = properties[Beacon.JSON_FLOOR_KEY] as! String
+        self.name = properties[Beacon.JSON_NAME_KEY] as? String
+        self.beaconDescription = properties[Beacon.JSON_DESCRIPTION_KEY] as? String
         
-        let coords = geometry[GeoJSON.COORDINATES_KEY] as! [CGFloat]
+        guard let proximityUUID = NSUUID(UUIDString: properties[Beacon.JSON_UUID_KEY] as! String) else {
+            self.major = nil
+            self.minor = nil
+            self.proximityUUID = nil
+            self.site = nil
+            self.floor = nil
+            self.x = nil
+            self.y = nil
+            return nil
+        }
         
-        self.x = coords[0]
-        self.y = coords[1]
+        self.proximityUUID = proximityUUID
+        
+        if let major = properties[Beacon.JSON_MAJOR_KEY] as? String {
+            self.major = CLBeaconMajorValue(major)
+        } else {
+            self.major = nil
+        }
+        if let minor =  properties[Beacon.JSON_MINOR_KEY] as? String {
+            self.minor = CLBeaconMinorValue(minor)
+        } else {
+            self.minor = nil
+        }
+        
+        self.site = properties[Beacon.JSON_SITE_KEY] as? String
+        self.floor = properties[Beacon.JSON_FLOOR_KEY] as? String
+        
+        if let coords = geometry[GeoJSON.COORDINATES_KEY] as? [CGFloat] {
+            self.x = coords[0]
+            self.y = coords[1]
+        } else {
+            self.x = nil
+            self.y = nil
+        }
     }
     
     /**
@@ -125,10 +157,14 @@ public class PIBeacon: NSObject {
         var dictionary: [String: AnyObject] = [:]
         
         dictionary[Beacon.JSON_NAME_KEY] = name
-        dictionary[Beacon.JSON_DESCRIPTION_KEY] = description
+        dictionary[Beacon.JSON_DESCRIPTION_KEY] = beaconDescription
         dictionary[Beacon.JSON_UUID_KEY] = proximityUUID
-        dictionary[Beacon.JSON_MAJOR_KEY] = major
-        dictionary[Beacon.JSON_MINOR_KEY] = minor
+        if let major = self.major {
+            dictionary[Beacon.JSON_MAJOR_KEY] = NSNumber(unsignedShort:major)
+        }
+        if let minor = self.minor {
+            dictionary[Beacon.JSON_MINOR_KEY] = NSNumber(unsignedShort:minor)
+        }
         dictionary[Beacon.JSON_X_KEY] = x
         dictionary[Beacon.JSON_Y_KEY] = y
         dictionary[Beacon.JSON_SITE_KEY] = site

--- a/PresenceInsightsSDK/PresenceInsightsSDK/PIDevice.swift
+++ b/PresenceInsightsSDK/PresenceInsightsSDK/PIDevice.swift
@@ -20,11 +20,11 @@
 import UIKit
 
 // MARK: - PIDevice object
-public class PIDevice: NSObject {
+public struct PIDevice {
     
     // Values every device has.
-    public var descriptor: String!
-    public var registered: Bool = false
+    public let descriptor: String?
+    public var registered: Bool
     
     // Optional values only registered devices have.
     public var code: String?
@@ -61,8 +61,15 @@ public class PIDevice: NSObject {
     
     - returns: An initialized PIDevice.
     */
-    public convenience override init() {
-        self.init(name: nil, type: nil, data: [:], unencryptedData: [:], registered: false, blacklist: false)
+    public init() {
+        self.name = nil
+        self.type = nil
+        self.data = nil
+        self.unencryptedData = nil
+        
+        self.registered = false
+        self.blacklist = nil
+        self.descriptor = nil
     }
     
     /**
@@ -72,8 +79,15 @@ public class PIDevice: NSObject {
 
     - returns: An initialized PIDevice.
     */
-    public convenience init(name: String) {
-        self.init(name: name, type: String(), data: [:], unencryptedData: [:], registered: false, blacklist: false)
+    public init(name: String) {
+        self.name = name
+        self.type = nil
+        self.data = nil
+        self.unencryptedData = nil
+        
+        self.registered = false
+        self.blacklist = nil
+        self.descriptor = nil
     }
     
     /**
@@ -83,31 +97,23 @@ public class PIDevice: NSObject {
 
     - returns: An initialized PIDevice.
     */
-    public convenience init(dictionary: [String: AnyObject]) {
+    public init(dictionary: [String: AnyObject]) {
         
-        self.init(name: nil, type: nil, data: [:], unencryptedData: [:], registered: false, blacklist: false)
+        self.descriptor = UIDevice.currentDevice().identifierForVendor?.UUIDString
         
-        if let name = dictionary[Device.JSON_NAME_KEY] as? String {
-            self.name = name
-        }
-        if let type =  dictionary[Device.JSON_TYPE_KEY] as? String {
-            self.type = type;
-        }
-        if let dictionary = dictionary[Device.JSON_DATA_KEY] as? [String: String] {
-            self.data = dictionary
-        }
-        if let dictionary = dictionary[Device.JSON_UNENCRYPTED_DATA_KEY] as? [String: String] {
-            self.unencryptedData = dictionary
-        }
-        if let blacklist = dictionary[Device.JSON_BLACKLIST_KEY] as? Bool {
-            self.blacklist = blacklist
-        }
+        self.name = dictionary[Device.JSON_NAME_KEY] as? String
         
-        self.registered = dictionary[Device.JSON_REGISTERED_KEY] as! Bool
+        self.type =  dictionary[Device.JSON_TYPE_KEY] as? String
         
-        if let code = dictionary[Device.JSON_CODE_KEY] as? String {
-            self.code = code
-        }
+        self.data = dictionary[Device.JSON_DATA_KEY] as? [String: String]
+        
+        self.unencryptedData = dictionary[Device.JSON_UNENCRYPTED_DATA_KEY] as? [String: String]
+        
+        self.blacklist = dictionary[Device.JSON_BLACKLIST_KEY] as? Bool
+        
+        self.registered = dictionary[Device.JSON_REGISTERED_KEY] as? Bool ?? false
+        
+        self.code = dictionary[Device.JSON_CODE_KEY] as? String
         
     }
     
@@ -117,13 +123,12 @@ public class PIDevice: NSObject {
     - parameter object:   Object to be stored
     - parameter key:      Key to use to store object
     */
-    public func addToDataObject(object: AnyObject, key: String) {
+    public mutating func addToDataObject(object: AnyObject, key: String) {
         if data == nil {
-            data![key] = object
-        } else {
             data = [:]
-            data![key] = object
         }
+        
+        data![key] = object
     }
     
     /**
@@ -132,13 +137,11 @@ public class PIDevice: NSObject {
     - parameter object:   Object to be stored
     - parameter key:      Key to use to store object
     */
-    public func addToUnencryptedDataObject(object: AnyObject, key: String) {
-        if unencryptedData != nil {
-            unencryptedData![key] = object
-        } else {
+    public mutating func addToUnencryptedDataObject(object: AnyObject, key: String) {
+        if unencryptedData == nil {
             unencryptedData = [:]
-            unencryptedData![key] = object
         }
+        unencryptedData?[key] = object
     }
     
     /**

--- a/PresenceInsightsSDK/PresenceInsightsSDK/PIFloor.swift
+++ b/PresenceInsightsSDK/PresenceInsightsSDK/PIFloor.swift
@@ -20,12 +20,12 @@
 import UIKit
 
 // MARK: - PIFloor object
-public class PIFloor: NSObject {
+public struct PIFloor {
 
     // Floor properties
-    public var name: String!
-    public var barriers: CGPoint!
-    public var z: Int!
+    public let name: String?
+    public let barriers: CGPoint?
+    public let z: Int?
 
     /**
     Default object initializer.
@@ -45,8 +45,10 @@ public class PIFloor: NSObject {
 
     - returns: An initialized PIFloor.
     */
-    public convenience override init() {
-        self.init(name: "", barriers: CGPoint() , z: 0)
+    public init() {
+        self.name = nil
+        self.barriers = nil
+        self.z = nil
     }
 
     /**
@@ -56,17 +58,19 @@ public class PIFloor: NSObject {
 
     - returns: An initialized PIFloor.
     */
-    public convenience init(dictionary: [String: AnyObject]) {
-
-        self.init(name: "", barriers: CGPoint(), z: 0)
+    public init(dictionary: [String: AnyObject]) {
 
         // retrieve dictionaries from feature object
         let geometry = dictionary[GeoJSON.GEOMETRY_KEY] as! [String: AnyObject]
         let properties = dictionary[GeoJSON.PROPERTIES_KEY] as! [String: AnyObject]
 
-        self.name = properties[Floor.JSON_NAME_KEY] as! String
-        self.z = properties[Floor.JSON_Z_KEY] as! Int
-        self.barriers = self.convertGeoJsonPayload(geometry[GeoJSON.COORDINATES_KEY] as! [CGFloat])
+        self.name = properties[Floor.JSON_NAME_KEY] as? String
+        self.z = properties[Floor.JSON_Z_KEY] as? Int
+        if let coordinates = geometry[GeoJSON.COORDINATES_KEY] as? [CGFloat] where coordinates.count == 2 {
+            self.barriers = CGPoint(x: coordinates[0], y: coordinates[1])
+        } else {
+            self.barriers = nil
+        }
 
     }
 
@@ -84,10 +88,6 @@ public class PIFloor: NSObject {
 
         return dictionary
 
-    }
-
-    func convertGeoJsonPayload(payload: [CGFloat]) -> CGPoint{
-        return CGPoint(x: payload.first!, y: payload.last!)
     }
 
 }

--- a/PresenceInsightsSDK/PresenceInsightsSDK/PIOrg.swift
+++ b/PresenceInsightsSDK/PresenceInsightsSDK/PIOrg.swift
@@ -20,13 +20,13 @@
 import UIKit
 
 // MARK: - PIOrg object
-public class PIOrg: NSObject {
+public struct PIOrg {
     
     // Org properties
-    public var name: String!
-    public var piDescription: String!
-    public var registrationTypes: [String]!
-    public var publicKey: String!
+    public var name: String?
+    public var piDescription: String?
+    public var registrationTypes: [String]?
+    public var publicKey: String?
     
     /**
     Default object initializer.
@@ -48,8 +48,11 @@ public class PIOrg: NSObject {
     
     - returns: An initialized PIOrg.
     */
-    public convenience override init() {
-        self.init(name: "", description: "", registrationTypes: [], publicKey: "")
+    public init() {
+        self.name = nil
+        self.piDescription = nil
+        self.registrationTypes = nil
+        self.publicKey = nil
     }
     
     /**
@@ -59,20 +62,12 @@ public class PIOrg: NSObject {
 
     - returns: An initialized PIOrg.
     */
-    public convenience init(dictionary: [String: AnyObject]) {
+    public init(dictionary: [String: AnyObject]) {
         
-        self.init(name: "", description: "", registrationTypes: [], publicKey: "")
-        
-        self.name = dictionary[Org.JSON_NAME_KEY] as! String
-        if let piDescription = dictionary[Beacon.JSON_DESCRIPTION_KEY] as? String {
-            self.piDescription = piDescription;
-        }
-        self.registrationTypes = dictionary[Org.JSON_REGISTRATION_TYPES_KEY] as! [String]
-        if let publicKey = dictionary[Org.JSON_PUBLIC_KEY_KEY] as? String {
-            self.publicKey = publicKey
-        } else {
-            self.publicKey = ""
-        }
+        self.name = dictionary[Org.JSON_NAME_KEY] as? String
+        self.piDescription = dictionary[Beacon.JSON_DESCRIPTION_KEY] as? String
+        self.registrationTypes = dictionary[Org.JSON_REGISTRATION_TYPES_KEY] as? [String]
+        self.publicKey = dictionary[Org.JSON_PUBLIC_KEY_KEY] as? String
         
     }
     
@@ -85,10 +80,18 @@ public class PIOrg: NSObject {
         
         var dictionary: [String: AnyObject] = [:]
         
-        dictionary[Org.JSON_NAME_KEY] = name
-        dictionary[Org.JSON_DESCRIPTION_KEY] = description
-        dictionary[Org.JSON_REGISTRATION_TYPES_KEY] = registrationTypes
-        dictionary[Org.JSON_PUBLIC_KEY_KEY] = publicKey
+        if let name = name {
+            dictionary[Org.JSON_NAME_KEY] = name
+        }
+        if let piDescription = piDescription {
+            dictionary[Org.JSON_DESCRIPTION_KEY] = piDescription
+        }
+        if let registrationTypes = registrationTypes {
+            dictionary[Org.JSON_REGISTRATION_TYPES_KEY] = registrationTypes
+        }
+        if let publicKey = publicKey {
+            dictionary[Org.JSON_PUBLIC_KEY_KEY] = publicKey
+        }
         
         return dictionary
         

--- a/PresenceInsightsSDK/PresenceInsightsSDK/PISensor.swift
+++ b/PresenceInsightsSDK/PresenceInsightsSDK/PISensor.swift
@@ -21,16 +21,16 @@ import UIKit
 import CoreLocation
 
 // MARK: - PISensor object
-public class PISensor: NSObject {
+public struct PISensor {
 
     // Sensor properties
-    public var name: String!
-    public var sensorDescription: String!
-    public var threshold: CGFloat!
-    public var x: CGFloat!
-    public var y: CGFloat!
-    public var site: String!
-    public var floor: String!
+    public let name: String?
+    public let sensorDescription: String?
+    public let threshold: CGFloat?
+    public let x: CGFloat?
+    public let y: CGFloat?
+    public let site: String?
+    public let floor: String?
 
     /**
     Default object initializer.
@@ -44,10 +44,10 @@ public class PISensor: NSObject {
         self.name = name
         self.sensorDescription = description
         self.threshold = threshold
-        self.x = 0.0
-        self.y = 0.0
-        self.site = ""
-        self.floor = ""
+        self.x = nil
+        self.y = nil
+        self.site = nil
+        self.floor = nil
     }
 
     /**
@@ -55,8 +55,14 @@ public class PISensor: NSObject {
 
     - returns: An initialized PISensor.
     */
-    public convenience override init() {
-        self.init(name: "", description: "", threshold: 0.0)
+    public init() {
+        self.name = nil
+        self.sensorDescription = nil
+        self.threshold = nil
+        self.x = nil
+        self.y = nil
+        self.site = nil
+        self.floor = nil
     }
 
     /**
@@ -66,29 +72,30 @@ public class PISensor: NSObject {
 
     - returns: An initialized PISensor.
     */
-    public convenience init(dictionary: [String: AnyObject]) {
+    public init(dictionary: [String: AnyObject]) {
 
         // I prefer this method because if the dictionary isn't built correctly it will at least throw a nil error at runtime.
-        self.init(name: "", description: "", threshold: 0.0)
 
         // retrieve dictionaries from feature object
-        let geometry = dictionary[GeoJSON.GEOMETRY_KEY] as! [String: AnyObject]
-        let properties = dictionary[GeoJSON.PROPERTIES_KEY] as! [String: AnyObject]
+        let geometry = dictionary[GeoJSON.GEOMETRY_KEY] as? [String: AnyObject]
+        let properties = dictionary[GeoJSON.PROPERTIES_KEY] as? [String: AnyObject]
 
-        self.name = properties[Sensor.JSON_NAME_KEY] as! String
+        self.name = properties?[Sensor.JSON_NAME_KEY] as? String
 
-        if let piDescription = dictionary[Sensor.JSON_DESCRIPTION_KEY] as? String {
-            self.sensorDescription = piDescription;
+        self.sensorDescription = dictionary[Sensor.JSON_DESCRIPTION_KEY] as? String
+        
+
+        self.threshold = properties?[Sensor.JSON_THRESHOLD_KEY] as? CGFloat
+        self.site = properties?[Sensor.JSON_SITE_KEY] as? String
+        self.floor = properties?[Sensor.JSON_FLOOR_KEY] as? String
+
+        if let coords = geometry?[GeoJSON.COORDINATES_KEY] as? [CGFloat] where coords.count == 2 {
+            self.x = coords[0]
+            self.y = coords[1]
+        } else {
+            self.x = nil
+            self.y = nil
         }
-
-        self.threshold = properties[Sensor.JSON_THRESHOLD_KEY] as! CGFloat
-        self.site = properties[Sensor.JSON_SITE_KEY] as! String
-        self.floor = properties[Sensor.JSON_FLOOR_KEY] as! String
-
-        let coords = geometry[GeoJSON.COORDINATES_KEY] as! [CGFloat]
-
-        self.x = coords[0]
-        self.y = coords[1]
     }
 
     /**
@@ -100,13 +107,25 @@ public class PISensor: NSObject {
 
         var dictionary: [String: AnyObject] = [:]
 
-        dictionary[Sensor.JSON_NAME_KEY] = name
-        dictionary[Sensor.JSON_DESCRIPTION_KEY] = sensorDescription
-        dictionary[Sensor.JSON_THRESHOLD_KEY] = threshold
-        dictionary[Sensor.JSON_X_KEY] = x
-        dictionary[Sensor.JSON_Y_KEY] = y
-        dictionary[Sensor.JSON_SITE_KEY] = site
-        dictionary[Sensor.JSON_FLOOR_KEY] = floor
+        if let name = name {
+            dictionary[Sensor.JSON_NAME_KEY] = name
+        }
+        if let sensorDescription = sensorDescription {
+            dictionary[Sensor.JSON_DESCRIPTION_KEY] = sensorDescription
+        }
+        if let threshold = threshold {
+            dictionary[Sensor.JSON_THRESHOLD_KEY] = threshold
+        }
+        if let x = x, y = y {
+            dictionary[Sensor.JSON_X_KEY] = x
+            dictionary[Sensor.JSON_Y_KEY] = y
+        }
+        if let site = site {
+            dictionary[Sensor.JSON_SITE_KEY] = site
+        }
+        if let floor = floor {
+            dictionary[Sensor.JSON_FLOOR_KEY] = floor
+        }
 
         return dictionary
 

--- a/PresenceInsightsSDK/PresenceInsightsSDK/PIZone.swift
+++ b/PresenceInsightsSDK/PresenceInsightsSDK/PIZone.swift
@@ -20,12 +20,12 @@
 import UIKit
 
 // MARK: - PIZone object
-public class PIZone: NSObject {
+public struct PIZone {
     
     // Zone properties
-    public var name: String!
-    public var polygon: [[CGPoint]]!
-    public var tags: [String]!
+    public let name: String?
+    public let polygon: [[CGPoint]]?
+    public let tags: [String]?
     
     /**
     Default object initializer.
@@ -45,8 +45,10 @@ public class PIZone: NSObject {
     
     - returns: An initialized PIOrg.
     */
-    public convenience override init() {
-        self.init(name: "", polygon: [[CGPoint]](), tags: [])
+    public init() {
+        self.name = nil
+        self.polygon = nil
+        self.tags = nil
     }
     
     /**
@@ -56,8 +58,10 @@ public class PIZone: NSObject {
 
     - returns: An initialized PIZone.
     */
-    public convenience init(name: String) {
-        self.init(name: name, polygon: [[CGPoint]](), tags: [])
+    public init(name: String) {
+        self.name = name
+        self.polygon = nil
+        self.tags = nil
     }
     
     /**
@@ -67,16 +71,19 @@ public class PIZone: NSObject {
 
     - returns: An initialized PIZone.
     */
-    public convenience init(dictionary: [String: AnyObject]) {
-        self.init(name: "", polygon: [[CGPoint]](), tags: [])
+    public init(dictionary: [String: AnyObject]) {
         
         // retrieve dictionaries from feature object
-        let geometry = dictionary[GeoJSON.GEOMETRY_KEY] as! [String: AnyObject]
-        let properties = dictionary[GeoJSON.PROPERTIES_KEY] as! [String: AnyObject]
+        let geometry = dictionary[GeoJSON.GEOMETRY_KEY] as? [String: AnyObject]
+        let properties = dictionary[GeoJSON.PROPERTIES_KEY] as? [String: AnyObject]
         
-        self.name = properties[Zone.JSON_NAME_KEY] as! String
-        self.tags = properties[Zone.JSON_TAGS_KEY] as! [String]
-        self.polygon = self.convertGeoJsonPayload(geometry[GeoJSON.COORDINATES_KEY] as! [[[CGFloat]]])
+        self.name = properties?[Zone.JSON_NAME_KEY] as? String
+        self.tags = properties?[Zone.JSON_TAGS_KEY] as? [String]
+        if let coordinates = geometry?[GeoJSON.COORDINATES_KEY] as? [[[CGFloat]]] {
+            self.polygon = convertGeoJsonPayload(coordinates)
+        } else {
+            self.polygon = nil
+        }
     }
     
     /**
@@ -87,25 +94,31 @@ public class PIZone: NSObject {
     public func toDictionary() -> [String: Any] {
         
         var dictionary: [String: Any] = [:]
-        
-        dictionary[Zone.JSON_NAME_KEY] = name
-        dictionary[Zone.JSON_POLYGON_KEY] = polygon
-        dictionary[Zone.JSON_TAGS_KEY] = tags
+        if let name = name {
+            dictionary[Zone.JSON_NAME_KEY] = name
+        }
+        if let polygon = polygon {
+            dictionary[Zone.JSON_POLYGON_KEY] = polygon
+        }
+        if let tags = tags {
+            dictionary[Zone.JSON_TAGS_KEY] = tags
+        }
         
         return dictionary
 
     }
     
-    func convertGeoJsonPayload(payload: [[[CGFloat]]]) -> [[CGPoint]]{
-        var returnPayload = [[CGPoint]]()
-        for polygonObj in payload {
-            var pointArray = [CGPoint]()
-            for points in polygonObj {
-                pointArray.append(CGPoint(x: points.first!, y: points.last!))
-            }
-            returnPayload.append(pointArray)
-        }
-        return returnPayload
-    }
-
 }
+
+private func convertGeoJsonPayload(payload: [[[CGFloat]]]) -> [[CGPoint]]{
+    var returnPayload = [[CGPoint]]()
+    for polygonObj in payload {
+        var pointArray = [CGPoint]()
+        for points in polygonObj {
+            pointArray.append(CGPoint(x: points.first!, y: points.last!))
+        }
+        returnPayload.append(pointArray)
+    }
+    return returnPayload
+}
+

--- a/PresenceInsightsSDK/PresenceInsightsSDK/RegionManager.swift
+++ b/PresenceInsightsSDK/PresenceInsightsSDK/RegionManager.swift
@@ -21,7 +21,7 @@ import Foundation
 import CoreLocation
 
 internal class RegionManager {
-    private var _locationManager: CLLocationManager
+    private let _locationManager: CLLocationManager
     private var _beaconRegions: [CLBeaconRegion] = []
     private var _uuidRegions: [CLBeaconRegion] = []
     private var _maxRegions: Int = 20
@@ -90,7 +90,7 @@ internal class RegionManager {
         _locationManager.startMonitoringForRegion(region)
     }
     
-    func didEnterRegion(region: CLRegion) {
+    func didEnterRegion(region: CLBeaconRegion) {
         for uuidRegion in _uuidRegions {
             if uuidRegion.identifier.lowercaseString == region.identifier.lowercaseString {
                 _locationManager.startRangingBeaconsInRegion(uuidRegion)
@@ -100,12 +100,12 @@ internal class RegionManager {
     }
     
     func didDetermineState(state: CLRegionState, region: CLRegion) {
-        if state.rawValue == CLRegionState.Inside.rawValue {
-            didEnterRegion(region)
+        if let region_ = region as? CLBeaconRegion where state.rawValue == CLRegionState.Inside.rawValue {
+            didEnterRegion(region_)
         }
     }
 
-    func didExitRegion(region: CLRegion){
+    func didExitRegion(region: CLBeaconRegion){
         for uuidRegion in _uuidRegions {
             if uuidRegion.identifier.lowercaseString == region.identifier.lowercaseString {
                 _locationManager.stopRangingBeaconsInRegion(uuidRegion)
@@ -126,7 +126,7 @@ internal class RegionManager {
         }
 
         // stop monitoring
-        for region: CLRegion in self._locationManager.monitoredRegions {
+        for case let region as CLBeaconRegion in self._locationManager.monitoredRegions {
             _locationManager.stopMonitoringForRegion(region)
         }
 

--- a/PresenceInsightsSDK/PresenceInsightsSDKTests/PresenceInsightsSDKTests.swift
+++ b/PresenceInsightsSDK/PresenceInsightsSDKTests/PresenceInsightsSDKTests.swift
@@ -40,8 +40,10 @@ class PresenceInsightsSDKTests: XCTestCase {
     // proximity uuids
     func testGetProximityUuids() {
         let expectation = expectationWithDescription("Test retrieving proximityUUIDs from org")
-        _adapter.getAllBeaconRegions { (result:[String], error) -> () in
-            XCTAssertGreaterThan(result.count, 0)
+        _adapter.getAllBeaconRegions { (result, error) -> () in
+            XCTAssertNotNil(error)
+            XCTAssertNotNil(result)
+            XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
         }
         waitForExpectationsWithTimeout(15.0, handler: nil)
@@ -49,7 +51,8 @@ class PresenceInsightsSDKTests: XCTestCase {
     // org
     func testGetOrg() {
         let expectation = expectationWithDescription("Test retrieving the org")
-        _adapter.getOrg { (result: PIOrg, error) -> () in
+        _adapter.getOrg { (result, error) -> () in
+            XCTAssertNotNil(error)
             XCTAssertNotNil(result, "Should not be nil")
             expectation.fulfill()
         }
@@ -59,8 +62,10 @@ class PresenceInsightsSDKTests: XCTestCase {
     // all sites
     func testGetAllSites() {
         let expectation = expectationWithDescription("Test retrieving all the sites in the org")
-        _adapter.getAllSites { (result: [String : String], error) -> () in
-            XCTAssertGreaterThan(result.count, 0)
+        _adapter.getAllSites { (result, error) -> () in
+            XCTAssertNotNil(error)
+            XCTAssertNotNil(result)
+            XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
         }
         waitForExpectationsWithTimeout(15.0, handler: nil)
@@ -68,8 +73,10 @@ class PresenceInsightsSDKTests: XCTestCase {
     // all floors
     func testGetAllFloors() {
         let expectation = expectationWithDescription("Test retrieving all the floors in the site")
-        _adapter.getAllFloors(PI.Site) { (result: [PIFloor], error) -> () in
-            XCTAssertGreaterThan(result.count, 0)
+        _adapter.getAllFloors(PI.Site) { (result, error) -> () in
+            XCTAssertNotNil(error)
+            XCTAssertNotNil(result)
+            XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
         }
         waitForExpectationsWithTimeout(15.0, handler: nil)
@@ -77,8 +84,10 @@ class PresenceInsightsSDKTests: XCTestCase {
     // all beacons
     func testGetAllBeacons() {
         let expectation = expectationWithDescription("Test retrieving all the beacons on a floor")
-        _adapter.getAllBeacons(PI.Site, floor: PI.Floor) { (result: [PIBeacon], error) -> () in
-            XCTAssertGreaterThan(result.count, 0)
+        _adapter.getAllBeacons(PI.Site, floor: PI.Floor) { (result, error) -> () in
+            XCTAssertNotNil(error)
+            XCTAssertNotNil(result)
+            XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
         }
         waitForExpectationsWithTimeout(15.0, handler: nil)
@@ -86,8 +95,10 @@ class PresenceInsightsSDKTests: XCTestCase {
     // all sensors
     func testGetAllSensors() {
         let expectation = expectationWithDescription("Test retrieving all the sensors on a floor")
-        _adapter.getAllSensors(PI.Site, floor: PI.Floor) { (result: [PISensor], error) -> () in
-            XCTAssertGreaterThan(result.count, 0)
+        _adapter.getAllSensors(PI.Site, floor: PI.Floor) { (result, error) -> () in
+            XCTAssertNotNil(error)
+            XCTAssertNotNil(result)
+            XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
         }
         waitForExpectationsWithTimeout(15.0, handler: nil)
@@ -95,8 +106,10 @@ class PresenceInsightsSDKTests: XCTestCase {
     // all zones
     func testGetAllZones() {
         let expectation = expectationWithDescription("Test retrieving all the zones on a floor")
-        _adapter.getAllZones(PI.Site, floor: PI.Floor) { (result: [PIZone], error) -> () in
-            XCTAssertGreaterThan(result.count, 0)
+        _adapter.getAllZones(PI.Site, floor: PI.Floor) { (result, error) -> () in
+            XCTAssertNotNil(error)
+            XCTAssertNotNil(result)
+            XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
         }
         waitForExpectationsWithTimeout(15.0, handler: nil)
@@ -104,7 +117,8 @@ class PresenceInsightsSDKTests: XCTestCase {
     // get map
     func testGetMap() {
         let expectation = expectationWithDescription("Test retrieving the floor map")
-        _adapter.getMap(PI.Site, floor: PI.Floor) { (result: UIImage, error) -> () in
+        _adapter.getMap(PI.Site, floor: PI.Floor) { (result, error) -> () in
+            XCTAssertNotNil(error)
             XCTAssertNotNil(result)
             expectation.fulfill()
         }
@@ -113,7 +127,8 @@ class PresenceInsightsSDKTests: XCTestCase {
     // register device
     func testRegisterDevice() {
         let expectation = expectationWithDescription("Test registering a device")
-        _adapter.registerDevice(_device, callback: { (result: PIDevice, error) -> () in
+        _adapter.registerDevice(_device, callback: { (result, error) -> () in
+            XCTAssertNotNil(error)
             XCTAssertNotNil(result)
             expectation.fulfill()
         })
@@ -123,8 +138,10 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testUpdateDevice() {
         let expectation = expectationWithDescription("Test updating a device")
         _device.name = "UpdatedTest"
-        _adapter.updateDevice(_device, callback: { (result: PIDevice, error) -> () in
-            XCTAssert(result.name == "UpdatedTest")
+        _adapter.updateDevice(_device, callback: { (result, error) -> () in
+            XCTAssertNotNil(error)
+            XCTAssertNotNil(result)
+            XCTAssert(result?.name == "UpdatedTest")
             expectation.fulfill()
         })
         waitForExpectationsWithTimeout(15.0, handler: nil)
@@ -132,8 +149,10 @@ class PresenceInsightsSDKTests: XCTestCase {
     // unregister device
     func testUnregisterDevice() {
         let expectation = expectationWithDescription("Test unregistering a device")
-        _adapter.unregisterDevice(_device, callback: { (result: PIDevice, error) -> () in
-            XCTAssertFalse(result.registered)
+        _adapter.unregisterDevice(_device, callback: { (result, error) -> () in
+            XCTAssertNotNil(error)
+            XCTAssertNotNil(result)
+            XCTAssertFalse(result!.registered)
             expectation.fulfill()
         })
         waitForExpectationsWithTimeout(15.0, handler: nil)


### PR DESCRIPTION
Hello,

I change as much the optional variable to avoid any to force-unwrap. Here is the recommend best practice for optionals taken for the Core Data book published by objc.io

<<Conventions for Optionals
Swift provides the Optional data type, which enables and forces us to explicitly think about and handle cases of missing values. We are big fans of this feature, and we use it consistently throughout all examples.
Consequently, we avoid using Swift’s ! operator to force-unwrap optionals (along with its usage to define implicitly unwrapped types). We consider this to be a code smell, since it undermines the safety that comes from having an optional type in the first place.
That being said, the single exception to this rule is properties that have to be set but cannot be set at initialization time. Examples of this are Interface Builder outlets or required delegate properties. In these cases, using implicitly unwrapped optionals follows the “crash early” rule: we want to notice immediately when one of these required properties has not been set.>>
- I changes most of the object to value type (Swift best practice)
- I fixed several bugs in 
  PIDevice.addToDataObject
  PIBeacon.toDictionary
  PIAdapter.sendBeaconPayload
  PIOrg.toDictionaray

In beacon manager, we only now touch beacon regions
