### PR TITLE
deprecated getDeviceByDescriptor. Removed use of the method in update…

### DIFF
--- a/PresenceInsightsSDKTests/PresenceInsightsSDKTests.swift
+++ b/PresenceInsightsSDKTests/PresenceInsightsSDKTests.swift
@@ -25,10 +25,7 @@ class PresenceInsightsSDKTests: XCTestCase {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
         _adapter = PIAdapter(tenant: PI.Tenant, org: PI.Org, baseURL: PI.Hostname, username: PI.Username, password: PI.Password)
-        _device = PIDevice(name: "test device")
-        _device.type = "External"
-        _device.registered = true
-        _device.blacklist = false
+        _device = PIDevice(name: "test device", type: "External", data: [:], unencryptedData: [:], registered: true, blacklist: false)
         _adapter.enableLogging()
     }
     
@@ -41,7 +38,7 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testGetProximityUuids() {
         let expectation = expectationWithDescription("Test retrieving proximityUUIDs from org")
         _adapter.getAllBeaconRegions { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result)
             XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
@@ -52,7 +49,7 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testGetOrg() {
         let expectation = expectationWithDescription("Test retrieving the org")
         _adapter.getOrg { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result, "Should not be nil")
             expectation.fulfill()
         }
@@ -63,7 +60,7 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testGetAllSites() {
         let expectation = expectationWithDescription("Test retrieving all the sites in the org")
         _adapter.getAllSites { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result)
             XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
@@ -74,7 +71,7 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testGetAllFloors() {
         let expectation = expectationWithDescription("Test retrieving all the floors in the site")
         _adapter.getAllFloors(PI.Site) { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result)
             XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
@@ -85,7 +82,7 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testGetAllBeacons() {
         let expectation = expectationWithDescription("Test retrieving all the beacons on a floor")
         _adapter.getAllBeacons(PI.Site, floor: PI.Floor) { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result)
             XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
@@ -96,7 +93,7 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testGetAllSensors() {
         let expectation = expectationWithDescription("Test retrieving all the sensors on a floor")
         _adapter.getAllSensors(PI.Site, floor: PI.Floor) { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result)
             XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
@@ -107,7 +104,7 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testGetAllZones() {
         let expectation = expectationWithDescription("Test retrieving all the zones on a floor")
         _adapter.getAllZones(PI.Site, floor: PI.Floor) { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result)
             XCTAssertGreaterThan(result!.count, 0)
             expectation.fulfill()
@@ -118,7 +115,7 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testGetMap() {
         let expectation = expectationWithDescription("Test retrieving the floor map")
         _adapter.getMap(PI.Site, floor: PI.Floor) { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result)
             expectation.fulfill()
         }
@@ -128,7 +125,7 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testRegisterDevice() {
         let expectation = expectationWithDescription("Test registering a device")
         _adapter.registerDevice(_device, callback: { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result)
             expectation.fulfill()
         })
@@ -139,7 +136,7 @@ class PresenceInsightsSDKTests: XCTestCase {
         let expectation = expectationWithDescription("Test updating a device")
         _device.name = "UpdatedTest"
         _adapter.updateDevice(_device, callback: { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result)
             XCTAssert(result?.name == "UpdatedTest")
             expectation.fulfill()
@@ -150,7 +147,7 @@ class PresenceInsightsSDKTests: XCTestCase {
     func testUnregisterDevice() {
         let expectation = expectationWithDescription("Test unregistering a device")
         _adapter.unregisterDevice(_device, callback: { (result, error) -> () in
-            XCTAssertNotNil(error)
+            XCTAssertNil(error)
             XCTAssertNotNil(result)
             XCTAssertFalse(result!.registered)
             expectation.fulfill()


### PR DESCRIPTION
…Device. Fixed bug where register device would fail if device document already existed in db. Fixed test cases.
